### PR TITLE
Add `signal.query.once` for signal queries that don't watch the cache

### DIFF
--- a/integration/angular/package.json
+++ b/integration/angular/package.json
@@ -10,8 +10,7 @@
     "codegen": "yarn codegen:core && yarn codegen:state",
     "codegen:core": "graphql-codegen --config ./projects/core/codegen.ts",
     "codegen:state": "graphql-codegen --config ./projects/state/codegen.ts",
-    "codegen:core:inspect": "node --nolazy --inspect-brk ../../node_modules/@graphql-codegen/cli/bin.js --config ./projects/core/codegen.ts",
-    "serve:ssr:core": "node dist/core/server/server.mjs"
+    "codegen:core:inspect": "node --nolazy --inspect-brk ../../node_modules/@graphql-codegen/cli/bin.js --config ./projects/core/codegen.ts"
   },
   "private": true,
   "dependencies": {

--- a/integration/angular/projects/core/src/main.server.ts
+++ b/integration/angular/projects/core/src/main.server.ts
@@ -1,7 +1,7 @@
-import { bootstrapApplication } from '@angular/platform-browser';
+import { bootstrapApplication, type BootstrapContext } from '@angular/platform-browser';
 import { AppComponent } from './app/app.component';
 import { config } from './app/app.config.server';
 
-const bootstrap = () => bootstrapApplication(AppComponent, config);
+const bootstrap = (context: BootstrapContext) => bootstrapApplication(AppComponent, config, context);
 
 export default bootstrap;

--- a/packages/angular/src/internal/queryResult.ts
+++ b/packages/angular/src/internal/queryResult.ts
@@ -1,0 +1,21 @@
+import { DataState, NetworkStatus } from '@apollo/client';
+import type { QueryResult } from '../types';
+
+export function emptyQueryResult<TData, TStates extends DataState<TData>['dataState']>(): QueryResult<TData, TStates> {
+  return {
+    data: undefined,
+    dataState: 'empty',
+    loading: false,
+    networkStatus: NetworkStatus.ready
+  } as QueryResult<TData, TStates>;
+}
+
+export function withPreviousData<TData, TStates extends DataState<TData>['dataState']>(
+  previous: QueryResult<TData, TStates> | undefined,
+  result: QueryResult<TData, TStates>
+): QueryResult<TData, TStates> {
+  return {
+    ...result,
+    previousData: previous?.data ?? previous?.previousData
+  } as QueryResult<TData, TStates>;
+}

--- a/packages/angular/src/queryObservable.ts
+++ b/packages/angular/src/queryObservable.ts
@@ -1,13 +1,14 @@
 import { DataState, ObservableQuery, OperationVariables, TypedDocumentNode, UpdateQueryMapFn, OperationVariables as Variables } from '@apollo/client';
 import { Observable, Subscription } from 'rxjs';
-import { ExtraWatchQueryOptions, GetData, QueryResult, SingleQueryResult, SubscribeToMoreOptions, WatchQueryOptions } from './types';
+import { withPreviousData } from './internal/queryResult';
+import { ExtraWatchQueryOptions, QueryResult, SingleQueryResult, SubscribeToMoreOptions, WatchQueryOptions } from './types';
 
 export class QueryObservable<
   TData = unknown,
   TVariables extends Variables = Variables,
   TStates extends DataState<TData>['dataState'] = DataState<TData>['dataState']
 > extends Observable<QueryResult<TData, TStates>> {
-  private previousData: GetData<TData, TStates> | undefined;
+  private previousResult: QueryResult<TData, TStates> | undefined;
 
   public constructor(
     private readonly observableQuery: ObservableQuery<TData, TVariables>,
@@ -17,9 +18,8 @@ export class QueryObservable<
       let subscription: Subscription | undefined;
 
       const next = ({ partial, ...result }: ObservableQuery.Result<TData>): void => {
-        const { previousData } = this;
-        this.previousData = (result.data ?? previousData) as GetData<TData, TStates> | undefined;
-        subscriber.next({ ...result, previousData } as QueryResult<TData, TStates>);
+        this.previousResult = withPreviousData(this.previousResult, result as QueryResult<TData, TStates>);
+        subscriber.next(this.previousResult);
       };
 
       const complete = (): void => {

--- a/packages/angular/src/signals/apolloSignal.ts
+++ b/packages/angular/src/signals/apolloSignal.ts
@@ -6,43 +6,53 @@ import { SignalCacheQuery, SignalCacheQueryOptions } from './cacheQuery';
 import { SignalFragment, SignalFragmentOptions } from './fragment';
 import { SignalMutation, SignalMutationOptions } from './mutation';
 import { SignalQuery, SignalQueryOptions } from './query';
+import { SignalSingleQuery, SignalSingleQueryOptions } from './singleQuery';
 import { SignalSubscription, SignalSubscriptionOptions } from './subscription';
+
+export interface SignalQueryFn {
+  <TData = unknown, TVariables extends Variables = Variables>(
+    options: SignalQueryOptions<TData, TVariables> & { returnPartialData: true }
+  ): SignalQuery<TData, TVariables, 'empty' | 'complete' | 'streaming' | 'partial'>;
+
+  <TData = unknown, TVariables extends Variables = Variables>(
+    options: SignalQueryOptions<TData, TVariables>
+  ): SignalQuery<TData, TVariables, 'empty' | 'complete' | 'streaming'>;
+
+  /**
+   * Create a query that fetches once per execution instead of watching the cache.
+   *
+   * It executes initially (unless `lazy`), whenever variables change and on `execute()`. Between executions the
+   * result signal keeps its last value. Cache writes and refetches elsewhere in the application never re-emit into it.
+   *
+   * This is the signal equivalent of `apollo.query`, whereas `signal.query` is the equivalent of `apollo.watchQuery`.
+   */
+  once<TData = unknown, TVariables extends Variables = Variables>(
+    options: SignalSingleQueryOptions<TData, TVariables>
+  ): SignalSingleQuery<TData, TVariables>;
+}
 
 export class ApolloSignal {
   public constructor(
     private readonly apollo: Apollo
   ) { }
 
-  public query<
-    TData = unknown,
-    TVariables extends Variables = Variables
-  >(
-    options: SignalQueryOptions<TData, TVariables> & { returnPartialData: true }
-  ): SignalQuery<TData, TVariables, 'empty' | 'complete' | 'streaming' | 'partial'>;
-
-  public query<
-    TData = unknown,
-    TVariables extends Variables = Variables
-  >(
-    options: SignalQueryOptions<TData, TVariables>
-  ): SignalQuery<TData, TVariables, 'empty' | 'complete' | 'streaming'>;
-
-  public query<
-    TData = unknown,
-    TVariables extends Variables = Variables
-  >(options: SignalQueryOptions<TData, TVariables>): SignalQuery<TData, TVariables, any> {
-    if (!options.injector) {
-      assertInInjectionContext(this.query.bind(this));
+  /**
+   * Create a reactive signal-based query that watches the cache for updates.
+   *
+   * Use `query.once` for a query that fetches once per execution instead.
+   */
+  public readonly query: SignalQueryFn = Object.assign(
+    (options: SignalQueryOptions<any, any>): SignalQuery<any, any, any> => {
+      const injector = this._ensureInjector(options, SignalQuery);
+      return new SignalQuery(injector, this.apollo, options);
+    },
+    {
+      once: (options: SignalSingleQueryOptions<any, any>): SignalSingleQuery<any, any> => {
+        const injector = this._ensureInjector(options, SignalSingleQuery);
+        return new SignalSingleQuery(injector, this.apollo, options);
+      }
     }
-
-    const injector = options.injector ?? inject(Injector);
-
-    return new SignalQuery<TData, TVariables>(
-      injector,
-      this.apollo,
-      options
-    );
-  }
+  );
 
   public mutation<
     TData = unknown,
@@ -62,11 +72,7 @@ export class ApolloSignal {
     TData = unknown,
     TVariables extends Variables = Variables
   >(options: SignalSubscriptionOptions<TData, TVariables>): SignalSubscription<TData, TVariables> {
-    if (!options.injector) {
-      assertInInjectionContext(this.subscription.bind(this));
-    }
-
-    const injector = options.injector ?? inject(Injector);
+    const injector = this._ensureInjector(options, SignalSubscription);
 
     return new SignalSubscription<TData, TVariables>(
       injector,
@@ -79,11 +85,7 @@ export class ApolloSignal {
     TData = unknown,
     TVariables extends Variables = Variables
   >(options: SignalFragmentOptions<TData, TVariables>): SignalFragment<TData, TVariables> {
-    if (!options.injector) {
-      assertInInjectionContext(this.fragment.bind(this));
-    }
-
-    const injector = options.injector ?? inject(Injector);
+    const injector = this._ensureInjector(options, SignalFragment);
 
     return new SignalFragment<TData, TVariables>(
       injector,
@@ -103,16 +105,25 @@ export class ApolloSignal {
   public cacheQuery<TData, TVariables extends Variables>(
     options: SignalCacheQueryOptions<TData, TVariables>
   ): SignalCacheQuery<TData, TVariables> {
-    if (!options.injector) {
-      assertInInjectionContext(this.cacheQuery.bind(this));
-    }
-
-    const injector = options.injector ?? inject(Injector);
+    const injector = this._ensureInjector(options, SignalCacheQuery);
 
     return new SignalCacheQuery<TData, TVariables>(
       injector,
       this.apollo.cache,
       options
     );
+  }
+
+  /**
+   * Signals must be created within an injection context unless an `injector` is provided explicitly.
+   *
+   * `signalType` only names the offending signal in the assertion message.
+   */
+  private _ensureInjector(options: { injector?: Injector }, signalType: new (...args: Array<any>) => unknown): Injector {
+    if (!options.injector) {
+      assertInInjectionContext(signalType);
+    }
+
+    return options.injector ?? inject(Injector);
   }
 }

--- a/packages/angular/src/signals/index.ts
+++ b/packages/angular/src/signals/index.ts
@@ -2,6 +2,7 @@ export * from './apolloSignal';
 export * from './cacheQuery';
 export * from './fragment';
 export * from './mutation';
+export * from './singleQuery';
 export * from './query';
 export * from './subscription';
 export * from './types';

--- a/packages/angular/src/signals/query.ts
+++ b/packages/angular/src/signals/query.ts
@@ -3,9 +3,10 @@ import { ApolloClient, DataState, DefaultContext, DocumentNode, ErrorLike, Error
 import { equal } from '@wry/equality';
 import { noop, Subscription } from 'rxjs';
 import { Apollo } from '../apollo';
+import { emptyQueryResult, withPreviousData } from '../internal/queryResult';
 import { QueryObservable } from '../queryObservable';
 import type { GetData, QueryResult, SingleQueryResult, SubscribeToMoreOptions, WatchQueryOptions } from '../types';
-import type { SignalVariablesOption } from './types';
+import type { SignalLazyVariablesOption } from './types';
 
 export class SignalQueryExecutionError extends Error {
   public constructor(methodName: keyof SignalQuery<any, any>) {
@@ -119,24 +120,7 @@ export type SignalQueryOptions<TData = unknown, TVariables extends Variables = V
    * Custom injector to use for this query.
    */
   injector?: Injector;
-} & (
-    | {
-      /**
-       * Whether to execute query immediately or lazily via `execute` method.
-       */
-      lazy: true;
-
-      /**
-      * A function or signal returning an object containing all of the GraphQL variables your query requires to execute.
-      *
-      * Each key in the object corresponds to a variable name, and that key's value corresponds to the variable value.
-      *
-      * When `null` is returned, the query will be terminated until a non-null value is returned again.
-      */
-      variables?: () => TVariables | undefined | null;
-    }
-    | SignalVariablesOption<NoInfer<TVariables>>
-  );
+} & SignalLazyVariablesOption<NoInfer<TVariables>>;
 
 export interface SignalQueryExecOptions<TVariables extends Variables = Variables> {
   /**
@@ -189,7 +173,7 @@ export class SignalQuery<TData, TVariables extends Variables = Variables, TState
   /**
    * Whether the query is currently active, subscribed to the underlying observable and receiving cache updates.
    */
-  public readonly active: Signal<boolean>;
+  public readonly active: Signal<boolean> = computed(() => this.subscription() !== undefined);
 
   /**
    * Whether the query is currently enabled.
@@ -211,8 +195,9 @@ export class SignalQuery<TData, TVariables extends Variables = Variables, TState
   public readonly enabled: Signal<boolean>;
 
   private observable: QueryObservable<TData, TVariables, TStates> | undefined;
-  private subscription: Subscription | undefined;
-  private readonly _active: WritableSignal<boolean>;
+  private resolvePendingTask: (() => void) | undefined;
+  private readonly subscription: WritableSignal<Subscription | undefined> = signal(undefined);
+  private readonly pendingTasks: PendingTasks;
   private readonly _result: WritableSignal<QueryResult<TData, TStates>>;
   private readonly _enabled: WritableSignal<boolean>;
 
@@ -223,16 +208,15 @@ export class SignalQuery<TData, TVariables extends Variables = Variables, TState
   ) {
     const { variables, lazy = false } = options;
 
+    this.pendingTasks = injector.get(PendingTasks);
+
     this.variables = variables !== undefined ? linkedSignal(variables, { equal }) : signal(variables);
 
     this._enabled = signal(!lazy);
     this.enabled = this._enabled.asReadonly();
 
-    this._result = signal({ data: undefined, dataState: 'empty', loading: false, networkStatus: NetworkStatus.ready } as QueryResult<TData, TStates>);
+    this._result = signal(emptyQueryResult<TData, TStates>());
     this.result = this._result.asReadonly();
-
-    this._active = signal(false);
-    this.active = this._active.asReadonly();
 
     effect(() => {
       const variables = this.variables();
@@ -251,17 +235,6 @@ export class SignalQuery<TData, TVariables extends Variables = Variables, TState
         this._terminate();
       }
     }, { injector });
-
-    if (!lazy) {
-      const pendingTasks = injector.get(PendingTasks);
-
-      effect(() => {
-        if (untracked(this.variables) !== null) {
-          const resolvePendingTask = pendingTasks.add();
-          this.execute().then(resolvePendingTask).catch(noop);
-        }
-      }, { injector });
-    }
 
     injector.get(DestroyRef).onDestroy(() => this.terminate());
   }
@@ -286,7 +259,7 @@ export class SignalQuery<TData, TVariables extends Variables = Variables, TState
    * Refetch the query with the current variables.
    */
   public refetch(variables?: Partial<TVariables>): Promise<SingleQueryResult<TData>> {
-    if (!this.observable) throw new SignalQueryExecutionError('refetch');
+    if (!this._isActive(this.observable)) throw new SignalQueryExecutionError('refetch');
     return this.observable.refetch(variables)
       .catch(error => ({ data: undefined, error }));
   }
@@ -298,7 +271,7 @@ export class SignalQuery<TData, TVariables extends Variables = Variables, TState
     TFetchData = TData,
     TFetchVars extends Variables = TVariables
   >(options: ObservableQuery.FetchMoreOptions<TData, TVariables, TFetchData, TFetchVars>): Promise<SingleQueryResult<TFetchData>> {
-    if (!this.observable) throw new SignalQueryExecutionError('fetchMore');
+    if (!this._isActive(this.observable)) throw new SignalQueryExecutionError('fetchMore');
     return this.observable.fetchMore(options)
       .catch(error => ({ data: undefined, error }));
   }
@@ -307,7 +280,7 @@ export class SignalQuery<TData, TVariables extends Variables = Variables, TState
    * Update the query's cached data.
    */
   public updateQuery(mapFn: UpdateQueryMapFn<TData, TVariables>): void {
-    if (!this.observable) throw new SignalQueryExecutionError('updateQuery');
+    if (!this._isActive(this.observable)) throw new SignalQueryExecutionError('updateQuery');
     this.observable.updateQuery(mapFn);
   }
 
@@ -315,7 +288,7 @@ export class SignalQuery<TData, TVariables extends Variables = Variables, TState
    * Start polling the query.
    */
   public startPolling(pollInterval: number): void {
-    if (!this.observable) throw new SignalQueryExecutionError('startPolling');
+    if (!this._isActive(this.observable)) throw new SignalQueryExecutionError('startPolling');
     this.observable.startPolling(pollInterval);
   }
 
@@ -323,7 +296,7 @@ export class SignalQuery<TData, TVariables extends Variables = Variables, TState
    * Stop polling the query.
    */
   public stopPolling(): void {
-    if (!this.observable) throw new SignalQueryExecutionError('stopPolling');
+    if (!this._isActive(this.observable)) throw new SignalQueryExecutionError('stopPolling');
     this.observable.stopPolling();
   }
 
@@ -341,7 +314,7 @@ export class SignalQuery<TData, TVariables extends Variables = Variables, TState
       TVariables
     >
   ): () => void {
-    if (!this.observable) throw new SignalQueryExecutionError('subscribeToMore');
+    if (!this._isActive(this.observable)) throw new SignalQueryExecutionError('subscribeToMore');
     return this.observable.subscribeToMore<TSubscriptionData, TSubscriptionVariables>(options);
   }
 
@@ -353,10 +326,8 @@ export class SignalQuery<TData, TVariables extends Variables = Variables, TState
     const variables = untracked(this.variables);
 
     if (variables === null) {
-      return Promise.resolve({ data: this.data() as TData | undefined });
+      return Promise.resolve({ data: untracked(this.data) as TData | undefined });
     }
-
-    this._active.set(true);
 
     const { query, lazy, notifyOnLoading = true, notifyOnNetworkStatusChange = true, ...options } = this.options;
 
@@ -370,23 +341,32 @@ export class SignalQuery<TData, TVariables extends Variables = Variables, TState
     } as WatchQueryOptions<TData, TVariables>;
 
     this.observable ??= this.apollo.watchQuery<TData, TVariables>(newOptions) as QueryObservable<TData, TVariables, any>;
-    this.subscription ??= this.observable.subscribe(result => this._result.set(result));
+
+    if (untracked(this.subscription) === undefined) {
+      this.subscription.set(this.observable.subscribe(result => this._result.set(result)));
+    }
+
+    const resolvePendingTask = this.pendingTasks.add();
+    this.resolvePendingTask = resolvePendingTask;
 
     return this.observable.reobserve(newOptions)
-      .catch(error => ({ data: undefined, error }));
+      .catch(error => ({ data: undefined, error }))
+      .finally(resolvePendingTask);
   }
 
   private _terminate(): void {
-    this._active.set(false);
-    this.subscription?.unsubscribe();
-    this.subscription = undefined;
-    this.observable = undefined;
-    this._result.update(({ data, previousData }) => ({
-      data: undefined,
-      dataState: 'empty',
-      loading: false,
-      networkStatus: NetworkStatus.ready,
-      previousData: data ?? previousData
-    }) as QueryResult<TData, TStates>);
+    untracked(this.subscription)?.unsubscribe();
+    this.subscription.set(undefined);
+    this.resolvePendingTask?.();
+    this.resolvePendingTask = undefined;
+    this._result.update(previous => withPreviousData(previous, emptyQueryResult<TData, TStates>()));
+  }
+
+  /**
+   * The observable is kept after termination so that it carries `previousData` into the next execution, so having
+   * one does not mean the query is running. The `undefined` check is only there to narrow the type.
+   */
+  private _isActive(observable: QueryObservable<TData, TVariables, TStates> | undefined): observable is QueryObservable<TData, TVariables, TStates> {
+    return observable !== undefined && untracked(this.active);
   }
 }

--- a/packages/angular/src/signals/singleQuery.ts
+++ b/packages/angular/src/signals/singleQuery.ts
@@ -1,0 +1,213 @@
+import { computed, DestroyRef, effect, Injector, linkedSignal, PendingTasks, signal, Signal, untracked, WritableSignal } from '@angular/core';
+import { ErrorLike, NetworkStatus, OperationVariables as Variables } from '@apollo/client';
+import { equal } from '@wry/equality';
+import { finalize, noop, Subscription } from 'rxjs';
+import { Apollo } from '../apollo';
+import { emptyQueryResult, withPreviousData } from '../internal/queryResult';
+import type { GetData, QueryOptions, QueryResult, SingleQueryResult } from '../types';
+import type { SignalQueryExecOptions } from './query';
+import type { SignalLazyVariablesOption } from './types';
+
+/**
+ * Assigned to the result of an execution that was cancelled before it produced one, either because newer variables
+ * superseded it or because the query was terminated. Without it, a cancelled execution would be indistinguishable
+ * from a query that completed with no data.
+ */
+export class SignalQueryCancelledError extends Error {
+  public constructor() {
+    super('Query execution was cancelled before it produced a result.');
+    this.name = 'SignalQueryCancelledError';
+  }
+}
+
+export type SignalSingleQueryOptions<TData = unknown, TVariables extends Variables = Variables> =
+  & Omit<QueryOptions<TData, TVariables>, 'variables' | 'notifyOnLoading' | 'throwError'>
+  & {
+    /**
+     * Whether or not to track initial network loading status.
+     * @default true
+     */
+    notifyOnLoading?: boolean;
+
+    /**
+     * Whether to execute query immediately or lazily via `execute` method.
+     */
+    lazy?: boolean;
+
+    /**
+     * Custom injector to use for this query.
+     */
+    injector?: Injector;
+  }
+  & SignalLazyVariablesOption<NoInfer<TVariables>>;
+
+/**
+ * A query that fetches once per execution instead of watching the cache.
+ *
+ * Executes initially (unless `lazy`), whenever variables change and on `execute()`. Between executions the result
+ * signal keeps its last value. Cache writes and refetches elsewhere in the application never re-emit into it.
+ */
+export class SignalSingleQuery<TData, TVariables extends Variables = Variables> {
+  /**
+   * The query result, containing `data`, `loading`, `error`, `networkStatus`, `previousData`, `dataState`.
+   */
+  public readonly result: Signal<QueryResult<TData, 'empty' | 'complete'>>;
+
+  /**
+   * If `true`, the query is currently in flight.
+   */
+  public readonly loading: Signal<boolean> = computed(() => this.result().loading);
+
+  /**
+   * The current network status of the query.
+   */
+  public readonly networkStatus: Signal<NetworkStatus> = computed(() => this.result().networkStatus);
+
+  /**
+   * The data returned by the query, or `undefined` if loading, errored, or no data received yet.
+   */
+  public readonly data: Signal<GetData<TData, 'empty' | 'complete'> | undefined> = computed(() => this.result().data);
+
+  /**
+   * The data from the previous execution, useful for displaying stale data while re-executing.
+   */
+  public readonly previousData: Signal<GetData<TData, 'empty' | 'complete'> | undefined> = computed(() => this.result().previousData);
+
+  /**
+   * An error object if the query failed, `undefined` otherwise.
+   */
+  public readonly error: Signal<ErrorLike | undefined> = computed(() => this.result().error);
+
+  /**
+   * A writable signal that represents the current query variables.
+   */
+  public readonly variables: WritableSignal<TVariables | undefined | null>;
+
+  /**
+   * Whether the query is currently active, having executed and not been terminated since.
+   */
+  public readonly active: Signal<boolean> = computed(() => this.execution() !== undefined);
+
+  /**
+   * Whether the query is currently enabled.
+   *
+   * This property starts as `true` for non-lazy queries and `false` for lazy queries.
+   *
+   * Calling `execute()` sets it to `true`, while calling `terminate()` sets it to `false`.
+   *
+   * When `true`:
+   * - The query automatically executes when variables change from `null` to a non-null value
+   * - Variable changes trigger re-execution with the new variables
+   *
+   * When `false`:
+   * - Variable changes are ignored and do not trigger re-execution
+   * - The query must be manually started via `execute()`
+   *
+   * Note: This is different from `active`, which indicates whether the query has executed and not been terminated since.
+   */
+  public readonly enabled: Signal<boolean>;
+
+  private resolvePendingTask: (() => void) | undefined;
+  private readonly execution: WritableSignal<{ variables: TVariables | undefined; subscription: Subscription } | undefined> = signal(undefined);
+  private readonly pendingTasks: PendingTasks;
+  private readonly _result: WritableSignal<QueryResult<TData, 'empty' | 'complete'>>;
+  private readonly _enabled: WritableSignal<boolean>;
+
+  public constructor(
+    injector: Injector,
+    private readonly apollo: Apollo,
+    private readonly options: SignalSingleQueryOptions<TData, TVariables>
+  ) {
+    const { variables, lazy = false } = options;
+
+    this.pendingTasks = injector.get(PendingTasks);
+
+    this.variables = variables !== undefined ? linkedSignal(variables, { equal }) : signal(variables);
+
+    this._enabled = signal(!lazy);
+    this.enabled = this._enabled.asReadonly();
+
+    this._result = signal(emptyQueryResult<TData, 'empty' | 'complete'>());
+    this.result = this._result.asReadonly();
+
+    effect(() => {
+      const variables = this.variables();
+      const enabled = untracked(this.enabled);
+
+      if (!enabled) return;
+
+      const execution = untracked(this.execution);
+
+      if (variables !== null) {
+        if (execution === undefined || execution.variables !== variables) {
+          this._execute({ variables }).catch(noop);
+        }
+      } else if (execution !== undefined) {
+        this._terminate();
+      }
+    }, { injector });
+
+    injector.get(DestroyRef).onDestroy(() => this.terminate());
+  }
+
+  /**
+   * Execute the query with the provided options.
+   */
+  public execute(execOptions: SignalQueryExecOptions<TVariables> = {}): Promise<SingleQueryResult<TData>> {
+    this._enabled.set(true);
+    return this._execute(execOptions);
+  }
+
+  /**
+   * Terminate the query, cancelling any in-flight execution and ignoring further variable changes.
+   */
+  public terminate(): void {
+    this._enabled.set(false);
+    this._terminate();
+  }
+
+  private _execute(execOptions: SignalQueryExecOptions<TVariables> = {}): Promise<SingleQueryResult<TData>> {
+    if ('variables' in execOptions) {
+      this.variables.set(execOptions.variables);
+    }
+
+    const variables = untracked(this.variables);
+
+    if (variables === null) {
+      return Promise.resolve({ data: untracked(this.data) });
+    }
+
+    untracked(this.execution)?.subscription.unsubscribe();
+
+    const { query, lazy, injector, notifyOnLoading = true, ...options } = this.options;
+
+    const resolvePendingTask = this.pendingTasks.add();
+    this.resolvePendingTask = resolvePendingTask;
+
+    return new Promise<SingleQueryResult<TData>>(resolve => {
+      const subscription = this.apollo.query<TData, TVariables>({
+        ...options,
+        ...execOptions,
+        notifyOnLoading,
+        throwError: false,
+        query,
+        variables
+      } as QueryOptions<TData, TVariables>).pipe(
+        finalize(() => resolve({ data: undefined, error: new SignalQueryCancelledError() }))
+      ).subscribe(result => {
+        if (!result.loading) resolve({ data: result.data, error: result.error });
+        this._result.update(previous => withPreviousData(previous, result));
+      });
+
+      this.execution.set({ variables, subscription });
+    }).finally(resolvePendingTask);
+  }
+
+  private _terminate(): void {
+    untracked(this.execution)?.subscription.unsubscribe();
+    this.execution.set(undefined);
+    this.resolvePendingTask?.();
+    this.resolvePendingTask = undefined;
+    this._result.update(previous => withPreviousData(previous, emptyQueryResult<TData, 'empty' | 'complete'>()));
+  }
+}

--- a/packages/angular/src/signals/subscription.ts
+++ b/packages/angular/src/signals/subscription.ts
@@ -4,7 +4,7 @@ import { equal } from '@wry/equality';
 import { Subscription } from 'rxjs';
 import { Apollo } from '../apollo';
 import { SubscriptionOptions, SubscriptionResult } from '../types';
-import { SignalVariablesOption } from './types';
+import { SignalLazyVariablesOption } from './types';
 
 // import { ApolloClient.SubscribeOptions as SignalSubscriptionOptions } from  '@apollo/client';
 export type SignalSubscriptionOptions<TData = unknown, TVariables extends Variables = Variables> = {
@@ -54,24 +54,7 @@ export type SignalSubscriptionOptions<TData = unknown, TVariables extends Variab
    * Custom injector to use for this subscription.
    */
   injector?: Injector;
-} & (
-    | {
-      /**
-       * Whether to execute subscription immediately or lazily via `execute` method.
-       */
-      lazy: true;
-
-      /**
-      * A function or signal returning an object containing all of the GraphQL variables your operation requires to execute.
-      *
-      * Each key in the object corresponds to a variable name, and that key's value corresponds to the variable value.*
-      *
-      * When `null` is returned, the subscription will be terminated until a non-null value is returned again.
-      */
-      variables?: () => TVariables | undefined | null;
-    }
-    | SignalVariablesOption<NoInfer<TVariables>>
-  );
+} & SignalLazyVariablesOption<NoInfer<TVariables>>;
 
 export interface SignalSubscriptionExecOptions<TVariables extends Variables = Variables> {
   /**
@@ -121,7 +104,7 @@ export class SignalSubscription<TData, TVariables extends Variables = Variables>
   /**
    * Whether the subscription is currently active, connected to the server and receiving real-time updates.
    */
-  public readonly active: Signal<boolean>;
+  public readonly active: Signal<boolean> = computed(() => this.execution() !== undefined);
 
   /**
    * Whether the subscription is currently enabled.
@@ -142,8 +125,7 @@ export class SignalSubscription<TData, TVariables extends Variables = Variables>
    */
   public readonly enabled: Signal<boolean>;
 
-  private subscription: Subscription | undefined;
-  private readonly _active: WritableSignal<boolean>;
+  private readonly execution: WritableSignal<{ variables: TVariables | undefined; subscription: Subscription } | undefined> = signal(undefined);
   private readonly _result: WritableSignal<SignalSubscriptionResult<TData>>;
   private readonly _enabled: WritableSignal<boolean>;
 
@@ -157,9 +139,6 @@ export class SignalSubscription<TData, TVariables extends Variables = Variables>
     this._enabled = signal(!lazy);
     this.enabled = this._enabled.asReadonly();
 
-    this._active = signal(false);
-    this.active = this._active.asReadonly();
-
     this._result = signal({ loading: false, data: undefined, error: undefined });
     this.result = this._result.asReadonly();
 
@@ -171,21 +150,17 @@ export class SignalSubscription<TData, TVariables extends Variables = Variables>
     effect(() => {
       const variables = this.variables();
       const enabled = untracked(this.enabled);
-      const active = untracked(this.active);
 
       if (!enabled) return;
 
-      if (variables !== null) {
-        this._execute({ variables });
-      } else if (active) {
-        this._terminate();
-      }
-    }, { injector });
+      const execution = untracked(this.execution);
 
-    effect(() => {
-      const variables = this.variables();
-      if (untracked(this.active) && variables !== null) {
-        this.execute({ variables });
+      if (variables !== null) {
+        if (execution === undefined || execution.variables !== variables) {
+          this._execute({ variables });
+        }
+      } else if (execution !== undefined) {
+        this._terminate();
       }
     }, { injector });
 
@@ -219,7 +194,6 @@ export class SignalSubscription<TData, TVariables extends Variables = Variables>
       return;
     }
 
-    this._active.set(true);
     this._result.set({
       loading: true,
       data: undefined,
@@ -227,37 +201,39 @@ export class SignalSubscription<TData, TVariables extends Variables = Variables>
     });
 
     const { subscription, onData, onError, onComplete, injector, lazy, ...options } = this.options;
-    this.subscription?.unsubscribe();
-    this.subscription = this.apollo.subscribe<TData, TVariables>({
-      ...options,
-      ...execOptions,
-      subscription,
-      variables
-    } as SubscriptionOptions<TData, TVariables>).subscribe({
-      next: result => {
-        this._result.set({
-          loading: false,
-          ...result
-        });
+    untracked(this.execution)?.subscription.unsubscribe();
+    this.execution.set({
+      variables,
+      subscription: this.apollo.subscribe<TData, TVariables>({
+        ...options,
+        ...execOptions,
+        subscription,
+        variables
+      } as SubscriptionOptions<TData, TVariables>).subscribe({
+        next: result => {
+          this._result.set({
+            loading: false,
+            ...result
+          });
 
-        if (result.error) {
-          onError?.(result.error);
-        } else if (result.data !== undefined) {
-          onData?.(result.data);
+          if (result.error) {
+            onError?.(result.error);
+          } else if (result.data !== undefined) {
+            onData?.(result.data);
+          }
+        },
+        // error is never called for subscriptions in Apollo Client
+        complete: () => {
+          this.terminate();
+          onComplete?.();
         }
-      },
-      // error is never called for subscriptions in Apollo Client
-      complete: () => {
-        this.terminate();
-        onComplete?.();
-      }
+      })
     });
   }
 
   private _terminate(): void {
-    this._active.set(false);
-    this.subscription?.unsubscribe();
-    this.subscription = undefined;
+    untracked(this.execution)?.subscription.unsubscribe();
+    this.execution.set(undefined);
     this._result.update(result => ({ ...result, loading: false }));
   }
 }

--- a/packages/angular/src/signals/types.ts
+++ b/packages/angular/src/signals/types.ts
@@ -19,3 +19,27 @@ export type SignalVariablesOption<TVariables extends Variables> = {} extends TVa
   */
   variables: () => TVariables | null;
 };
+
+/**
+ * Variables option for an operation that can be lazy.
+ *
+ * When `lazy` is `true`, variables are always optional, even when the operation requires them, because
+ * they can be provided later via `execute`.
+ */
+export type SignalLazyVariablesOption<TVariables extends Variables> =
+  | {
+    /**
+     * Whether to execute the operation immediately or lazily via `execute` method.
+     */
+    lazy: true;
+
+    /**
+    * A function or signal returning an object containing all of the GraphQL variables your operation requires to execute.
+    *
+    * Each key in the object corresponds to a variable name, and that key's value corresponds to the variable value.
+    *
+    * When `null` is returned, the operation will be terminated until a non-null value is returned again.
+    */
+    variables?: () => TVariables | undefined | null;
+  }
+  | SignalVariablesOption<TVariables>;

--- a/packages/angular/tests/signals.spec.ts
+++ b/packages/angular/tests/signals.spec.ts
@@ -1,6 +1,6 @@
-import { Injector, signal } from '@angular/core';
+import { Injector, PendingTasks, signal } from '@angular/core';
 import { fakeAsync, TestBed, tick } from '@angular/core/testing';
-import { Apollo, SingleQueryResult } from '@apollo-orbit/angular';
+import { Apollo, SignalQueryCancelledError, SingleQueryResult } from '@apollo-orbit/angular';
 import { gql, NetworkStatus, TypedDocumentNode } from '@apollo/client';
 import { MockLink, MockSubscriptionLink } from '@apollo/client/testing';
 import { GraphQLError } from 'graphql';
@@ -684,6 +684,8 @@ describe('Signals', () => {
         signalQuery.execute();
         tick();
         expect(signalQuery.data()).toEqual({ book: { id: 2, name: 'Book 2' } });
+        // The observable is kept while terminated, so the previousData it tracks survives the cycle
+        expect(signalQuery.previousData()).toEqual({ book: { id: 1, name: 'Book 1' } });
 
         mockLink.addMockedResponse({
           request: { query, variables: { id: 3 } },
@@ -855,6 +857,328 @@ describe('Signals', () => {
       it('should compile with optional variables', () => {
         apollo.signal.query({ injector, query: queryOptional });
         apollo.signal.query({ injector, query: queryOptional, variables: () => ({ id: '1' }) });
+        expect(true).toBe(true);
+      });
+    });
+  });
+
+  describe('SignalSingleQuery', () => {
+    it('should fetch once and ignore later cache updates', fakeAsync(() => {
+      const query = gql`query { value }`;
+
+      mockLink.addMockedResponse({
+        request: { query },
+        result: { data: { value: 'initial' } },
+        delay: 10
+      });
+
+      const singleQuery = apollo.signal.query.once<Value>({ query, injector });
+      const watchQuery = apollo.signal.query<Value>({ query, injector });
+
+      tick(0);
+      expect(singleQuery.loading()).toBe(true);
+      expect(singleQuery.data()).toBeUndefined();
+
+      tick(10);
+      expect(singleQuery.loading()).toBe(false);
+      expect(singleQuery.data()).toEqual({ value: 'initial' });
+      expect(watchQuery.data()).toEqual({ value: 'initial' });
+
+      apollo.cache.writeQuery({ query, data: { value: 'external' } });
+      tick();
+
+      expect(watchQuery.data()).toEqual({ value: 'external' });
+      expect(singleQuery.data()).toEqual({ value: 'initial' });
+      expect(singleQuery.error()).toBeUndefined();
+    }));
+
+    it('should re-execute when variables change', fakeAsync(() => {
+      const query = gql`query GetValue($id: ID!) { value(id: $id) }`;
+
+      mockLink.addMockedResponse({
+        request: { query, variables: { id: '1' } },
+        result: { data: { value: 'value-1' } }
+      });
+
+      mockLink.addMockedResponse({
+        request: { query, variables: { id: '2' } },
+        result: { data: { value: 'value-2' } }
+      });
+
+      const variables = signal({ id: '1' });
+      const singleQuery = apollo.signal.query.once({ query, variables, injector });
+
+      tick();
+      expect(singleQuery.data()).toEqual({ value: 'value-1' });
+
+      variables.set({ id: '2' });
+      tick();
+
+      expect(singleQuery.data()).toEqual({ value: 'value-2' });
+      expect(singleQuery.previousData()).toEqual({ value: 'value-1' });
+    }));
+
+    it('should ignore results from a superseded execution', fakeAsync(() => {
+      const query = gql`query GetValue($id: ID!) { value(id: $id) }`;
+
+      mockLink.addMockedResponse({
+        request: { query, variables: { id: '1' } },
+        result: { data: { value: 'value-1' } },
+        delay: 50
+      });
+
+      mockLink.addMockedResponse({
+        request: { query, variables: { id: '2' } },
+        result: { data: { value: 'value-2' } },
+        delay: 10
+      });
+
+      const variables = signal({ id: '1' });
+      const singleQuery = apollo.signal.query.once({ query, variables, injector });
+
+      tick(5);
+      variables.set({ id: '2' });
+      tick(10);
+
+      expect(singleQuery.data()).toEqual({ value: 'value-2' });
+
+      tick(50);
+      expect(singleQuery.data()).toEqual({ value: 'value-2' });
+    }));
+
+    it('should execute once when executed manually before the first effect run', fakeAsync(() => {
+      const query = gql`query { value }`;
+
+      mockLink.addMockedResponse({
+        request: { query },
+        result: { data: { value: 'expected' } }
+      });
+
+      const querySpy = vi.spyOn(apollo.client, 'query');
+      const singleQuery = apollo.signal.query.once<Value>({ query, injector });
+
+      let result: SingleQueryResult<Value> | undefined;
+      singleQuery.execute().then(executed => {
+        result = executed;
+      });
+      tick();
+
+      expect(querySpy).toHaveBeenCalledTimes(1);
+      expect(result?.data).toEqual({ value: 'expected' });
+      expect(singleQuery.data()).toEqual({ value: 'expected' });
+    }));
+
+    it('should report active while an execution is in flight', fakeAsync(() => {
+      const query = gql`query { value }`;
+
+      mockLink.addMockedResponse({
+        request: { query },
+        result: { data: { value: 'expected' } },
+        delay: 10
+      });
+
+      const singleQuery = apollo.signal.query.once<Value>({ query, injector });
+
+      expect(singleQuery.active()).toBe(false);
+
+      tick(0);
+      expect(singleQuery.active()).toBe(true);
+
+      tick(10);
+      expect(singleQuery.active()).toBe(true);
+
+      singleQuery.terminate();
+      expect(singleQuery.active()).toBe(false);
+      expect(singleQuery.enabled()).toBe(false);
+    }));
+
+    it('should resolve a cancelled execution with an error rather than as an empty result', fakeAsync(() => {
+      const query = gql`query GetValue($id: ID!) { value(id: $id) }`;
+
+      mockLink.addMockedResponse({
+        request: { query, variables: { id: '1' } },
+        result: { data: { value: 'value-1' } },
+        delay: 50
+      });
+
+      mockLink.addMockedResponse({
+        request: { query, variables: { id: '2' } },
+        result: { data: { value: 'value-2' } },
+        delay: 10
+      });
+
+      const variables = signal({ id: '1' });
+      const singleQuery = apollo.signal.query.once({ query, variables, injector });
+
+      let superseded: SingleQueryResult<unknown> | undefined;
+      tick(0);
+      singleQuery.execute().then(result => {
+        superseded = result;
+      });
+
+      tick(5);
+      variables.set({ id: '2' });
+      tick(60);
+
+      expect(superseded?.data).toBeUndefined();
+      expect(superseded?.error).toBeInstanceOf(SignalQueryCancelledError);
+      expect(singleQuery.data()).toEqual({ value: 'value-2' });
+    }));
+
+    it('should resolve with an error when terminated mid-flight', fakeAsync(() => {
+      const query = gql`query { value }`;
+
+      mockLink.addMockedResponse({
+        request: { query },
+        result: { data: { value: 'expected' } },
+        delay: 50
+      });
+
+      const singleQuery = apollo.signal.query.once<Value>({ query, lazy: true, injector });
+
+      let terminated: SingleQueryResult<Value> | undefined;
+      singleQuery.execute().then(result => {
+        terminated = result;
+      });
+
+      tick(5);
+      singleQuery.terminate();
+      tick(50);
+
+      expect(terminated?.data).toBeUndefined();
+      expect(terminated?.error).toBeInstanceOf(SignalQueryCancelledError);
+      expect(singleQuery.data()).toBeUndefined();
+      expect(singleQuery.active()).toBe(false);
+    }));
+
+    it('should terminate when variables become null and return current data when executed', fakeAsync(() => {
+      const query = gql`query GetValue($id: ID!) { value(id: $id) }`;
+
+      mockLink.addMockedResponse({
+        request: { query, variables: { id: '1' } },
+        result: { data: { value: 'value-1' } }
+      });
+
+      const id = signal<string | null>('1');
+
+      const singleQuery = apollo.signal.query.once({
+        query,
+        variables: () => id() !== null ? ({ id: id() }) : null,
+        injector
+      });
+
+      tick();
+      expect(singleQuery.data()).toEqual({ value: 'value-1' });
+      expect(singleQuery.networkStatus()).toBe(NetworkStatus.ready);
+      expect(singleQuery.active()).toBe(true);
+
+      // Setting variables to null terminates the execution, data resets and previousData keeps the last value
+      id.set(null);
+      tick();
+
+      expect(singleQuery.active()).toBe(false);
+      expect(singleQuery.data()).toBeUndefined();
+      expect(singleQuery.previousData()).toEqual({ value: 'value-1' });
+
+      // Executing with null variables resolves with the current data instead of fetching
+      let result: SingleQueryResult<unknown> | undefined;
+      singleQuery.execute().then(executed => {
+        result = executed;
+      });
+      tick();
+
+      expect(result?.data).toBeUndefined();
+      expect(singleQuery.active()).toBe(false);
+    }));
+
+    it('should not execute while variables are null or the query is terminated', fakeAsync(() => {
+      const query = gql`query GetValue($id: ID!) { value(id: $id) }`;
+
+      const querySpy = vi.spyOn(apollo.client, 'query');
+      const id = signal<string | null>(null);
+
+      const singleQuery = apollo.signal.query.once({
+        query,
+        variables: () => id() !== null ? ({ id: id() }) : null,
+        injector
+      });
+
+      // Starting with null variables leaves nothing to execute and nothing to terminate
+      tick();
+      expect(querySpy).not.toHaveBeenCalled();
+      expect(singleQuery.active()).toBe(false);
+
+      // Once terminated, variable changes are ignored
+      singleQuery.terminate();
+      id.set('1');
+      tick();
+
+      expect(querySpy).not.toHaveBeenCalled();
+      expect(singleQuery.enabled()).toBe(false);
+    }));
+
+    it('should expose errors on the result', fakeAsync(() => {
+      const query = gql`query { value }`;
+
+      mockLink.addMockedResponse({
+        request: { query },
+        result: { errors: [new GraphQLError('Query error')] }
+      });
+
+      const singleQuery = apollo.signal.query.once<Value>({ query, injector });
+
+      tick();
+
+      expect(singleQuery.loading()).toBe(false);
+      expect(singleQuery.data()).toBeUndefined();
+      expect(singleQuery.error()?.message).toContain('Query error');
+    }));
+
+    it('should execute lazily and resolve with the result', async () => {
+      const query = gql`query { value }`;
+
+      mockLink.addMockedResponse({
+        request: { query },
+        result: { data: { value: 'expected' } }
+      });
+
+      const singleQuery = apollo.signal.query.once<Value>({ query, lazy: true, injector });
+
+      expect(singleQuery.enabled()).toBe(false);
+      expect(singleQuery.data()).toBeUndefined();
+
+      const result = await singleQuery.execute();
+
+      expect(result.data).toEqual({ value: 'expected' });
+      expect(singleQuery.data()).toEqual({ value: 'expected' });
+      expect(singleQuery.enabled()).toBe(true);
+    });
+
+    describe('variables type safety', () => {
+      const query: TypedDocumentNode<{ value: string }, { id: string }> = gql`query Value($id: ID!) { value(id: $id) }`;
+      const queryOptional: TypedDocumentNode<{ value: string }, Exact<{ id?: string }>> = gql`query Value($id: ID) { value(id: $id) }`;
+
+      it('should raise a compiler error if variables are required but not provided (and not lazy)', () => {
+        // @ts-expect-error: Property 'variables' is missing in type
+        apollo.signal.query.once({ injector, query });
+        // @ts-expect-error: Property 'variables' is missing in type
+        apollo.signal.query.once({ injector, query, lazy: false });
+        expect(true).toBe(true);
+      });
+
+      it('should compile if lazy is true, even if required variables are not provided initially', () => {
+        apollo.signal.query.once({ injector, query, lazy: true });
+        expect(true).toBe(true);
+      });
+
+      it('should compile if required variables are provided (and not lazy)', () => {
+        apollo.signal.query.once({ injector, query, variables: () => ({ id: '1' }) });
+        expect(true).toBe(true);
+      });
+
+      it('should compile with optional variables', () => {
+        apollo.signal.query.once({ injector, query: queryOptional });
+        apollo.signal.query.once({ injector, query: queryOptional, variables: () => ({ id: '1' }) });
         expect(true).toBe(true);
       });
     });
@@ -1651,6 +1975,40 @@ describe('Signals', () => {
       }));
     });
 
+    describe('single subscription per trigger', () => {
+      it('should subscribe exactly once on initialization', fakeAsync(() => {
+        const subscription = gql`subscription { newValue }`;
+
+        const subscribeSpy = vi.spyOn(apollo, 'subscribe');
+
+        apollo.signal.subscription<{ newValue: string }>({
+          subscription,
+          injector
+        });
+
+        tick();
+
+        expect(subscribeSpy).toHaveBeenCalledTimes(1);
+      }));
+
+      it('should subscribe exactly once when executed manually before the first effect run', fakeAsync(() => {
+        const subscription = gql`subscription { newValue }`;
+
+        const subscribeSpy = vi.spyOn(apollo, 'subscribe');
+
+        const signalSubscription = apollo.signal.subscription<{ newValue: string }>({
+          subscription,
+          lazy: true,
+          injector
+        });
+
+        signalSubscription.execute();
+        tick();
+
+        expect(subscribeSpy).toHaveBeenCalledTimes(1);
+      }));
+    });
+
     describe('execute with null variables', () => {
       it('should handle execute when variables are null', fakeAsync(() => {
         const subscription = gql`subscription BookUpdated($id: Int!) { bookUpdated(id: $id) { id } }`;
@@ -1812,12 +2170,97 @@ describe('Signals', () => {
     }));
   });
 
+  describe('Application stability', () => {
+    /**
+     * Counts the tasks a signal registers with `PendingTasks` and how many it releases. A task that is never
+     * released leaves the application permanently unstable and stalls server-side rendering.
+     */
+    function trackPendingTasks(): { added: number; released: number } {
+      const pendingTasks = TestBed.inject(PendingTasks);
+      const counters = { added: 0, released: 0 };
+      const add = pendingTasks.add.bind(pendingTasks);
+
+      vi.spyOn(pendingTasks, 'add').mockImplementation(() => {
+        counters.added++;
+        const remove = add();
+        let released = false;
+
+        // `PendingTasks` cleanups are idempotent, so count removals rather than calls.
+        return () => {
+          if (!released) {
+            released = true;
+            counters.released++;
+          }
+          remove();
+        };
+      });
+
+      return counters;
+    }
+
+    it('should release the pending task when a query is terminated mid-flight', fakeAsync(() => {
+      const query = gql`query GetValue($id: ID!) { value(id: $id) }`;
+
+      mockLink.addMockedResponse({
+        request: { query, variables: { id: '1' } },
+        result: { data: { value: 'value-1' } },
+        delay: 50
+      });
+
+      const tasks = trackPendingTasks();
+      const variables = signal<{ id: string } | null>({ id: '1' });
+
+      const signalQuery = apollo.signal.query({ query, variables, injector });
+
+      tick(0);
+      expect(tasks).toEqual({ added: 1, released: 0 });
+
+      // Terminating abandons the in-flight `reobserve`, so the task must be released now rather than when the
+      // response that is no longer needed arrives.
+      signalQuery.terminate();
+      expect(tasks).toEqual({ added: 1, released: 1 });
+
+      tick(50);
+      expect(tasks).toEqual({ added: 1, released: 1 });
+    }));
+
+    it('should release the pending task when a single query is terminated mid-flight', fakeAsync(() => {
+      const query = gql`query { value }`;
+
+      mockLink.addMockedResponse({
+        request: { query },
+        result: { data: { value: 'expected' } },
+        delay: 50
+      });
+
+      const tasks = trackPendingTasks();
+      const singleQuery = apollo.signal.query.once<Value>({ query, injector });
+
+      tick(0);
+      expect(tasks).toEqual({ added: 1, released: 0 });
+
+      singleQuery.terminate();
+      expect(tasks).toEqual({ added: 1, released: 1 });
+
+      tick(50);
+      expect(tasks).toEqual({ added: 1, released: 1 });
+    }));
+  });
+
   describe('Injection Context', () => {
     it('should throw when query is called without injector outside injection context', () => {
       const query = gql`query { value }`;
 
       expect(() => {
         apollo.signal.query<Value>({ query });
+      }).toThrow();
+    });
+
+    it('should throw when query.once is called without injector outside injection context', () => {
+      const query = gql`query { value }`;
+
+      expect(() => {
+        apollo.signal.query.once<Value>({ query });
       }).toThrow();
     });
 

--- a/scripts/syncApolloTypes.ts
+++ b/scripts/syncApolloTypes.ts
@@ -212,24 +212,7 @@ function getProcessedDefinitionText(declarationNode: ts.Declaration, typeName: s
    * Custom injector to use for this query.
    */
   injector?: Injector;
-} & (
-    | {
-      /**
-       * Whether to execute query immediately or lazily via \`execute\` method.
-       */
-      lazy: true;
-
-      /**
-      * A function or signal returning an object containing all of the GraphQL variables your query requires to execute.
-      *
-      * Each key in the object corresponds to a variable name, and that key's value corresponds to the variable value.
-      *
-      * When \`null\` is returned, the query will be terminated until a non-null value is returned again.
-      */
-      variables?: () => TVariables | undefined | null;
-    }
-    | SignalVariablesOption<NoInfer<TVariables>>
-  );`);
+} & SignalLazyVariablesOption<NoInfer<TVariables>>;`);
   }
 
   if (asName === 'SubscriptionOptions') {
@@ -268,24 +251,7 @@ function getProcessedDefinitionText(declarationNode: ts.Declaration, typeName: s
    * Custom injector to use for this subscription.
    */
   injector?: Injector;
-} & (
-    | {
-      /**
-       * Whether to execute subscription immediately or lazily via \`execute\` method.
-       */
-      lazy: true;
-
-      /**
-      * A function or signal returning an object containing all of the GraphQL variables your operation requires to execute.
-      *
-      * Each key in the object corresponds to a variable name, and that key's value corresponds to the variable value.*
-      *
-      * When \`null\` is returned, the subscription will be terminated until a non-null value is returned again.
-      */
-      variables?: () => TVariables | undefined | null;
-    }
-    | SignalVariablesOption<NoInfer<TVariables>>
-  )`);
+} & SignalLazyVariablesOption<NoInfer<TVariables>>`);
   }
 
   if (asName === 'SignalFragmentOptions') {


### PR DESCRIPTION
Add `signal.query.once` for queries that don't watch the cache